### PR TITLE
Use django.shortcuts `render_to_response` and `redirect` instead of deprecated function-based views. Also fixes InlineAdminFormSet instantiation issue - all issues: #27, #30, #32

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ also hang other content off of it.
 Requirements
 --------------
 
-* `Django <http://djangoproject.com>`_   (1.3.3 or higher)
+* `Django <http://djangoproject.com>`_   (1.4 or higher)
 * `django-treebeard <https://tabo.pe/projects/django-treebeard/>`_.
 
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -13,7 +13,10 @@ By default, scaffold uses a common URL addressing scheme for sections and subsec
 
 But, let's say you want a simpler scheme, with URLs like ``"/sections/local/"`` or ``"/sections/water/"``. Heres how our URL conf file looked at the end of the last section::
 
-    from django.conf.urls.defaults import *
+    try:
+        from django.conf.urls import *
+    except ImportError:
+        from django.conf.urls.defaults import *
 
     from django.contrib import admin
     admin.autodiscover()

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -45,7 +45,10 @@ Now we can create a model which adds the fields we need. In the ``models.py`` fo
 
 Change the default urls.py file for your Django project to the following::
 
-    from django.conf.urls.defaults import *
+    try:
+        from django.conf.urls import *
+    except ImportError:
+        from django.conf.urls.defaults import *
 
     from django.contrib import admin
     admin.autodiscover()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.3.3
+Django>=1.4
 django-treebeard==1.61

--- a/scaffold/admin.py
+++ b/scaffold/admin.py
@@ -13,14 +13,14 @@ from django.core.urlresolvers import reverse, NoReverseMatch
 from django.db import models, transaction
 from django.forms.formsets import all_valid
 from django.http import HttpResponseBadRequest, HttpResponseServerError, Http404
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect, render_to_response
+from django.template import RequestContext
 from django.utils.encoding import force_unicode
 from django.forms.util import ErrorList
 from django.utils.functional import update_wrapper
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
-from django.views.generic import simple
 
 from forms import SectionForm
 import app_settings
@@ -30,6 +30,7 @@ allow_associated_ordering = app_settings.ALLOW_ASSOCIATED_ORDERING
 model_proxy = app_settings.get_extending_model()
 
 csrf_protect_m = admin.options.csrf_protect_m
+
 
 class SectionAdmin(admin.ModelAdmin):
 
@@ -107,10 +108,7 @@ class SectionAdmin(admin.ModelAdmin):
         """
         context.update(self.app_context)
         template_path = self.template_base + template
-        return simple.direct_to_template(request,
-            template = template_path,
-            extra_context = context
-        )
+        return render_to_response(template_path, context, context_instance=RequestContext(request))
 
     def redirect_to_scaffold_index(self, request):
         """Redirect to the change list page of your model."""
@@ -118,10 +116,7 @@ class SectionAdmin(admin.ModelAdmin):
             'admin:%(app_label)s_%(module_label)s_changelist'
             % self.app_context
         )
-        return simple.redirect_to(request,
-            url=redirect_url,
-            permanent=False
-        )
+        return redirect(redirect_url, permanent=False)
 
     def redirect_to_object_changeform(self, request, obj):
         """Redirect to the change form of the given object."""
@@ -129,10 +124,7 @@ class SectionAdmin(admin.ModelAdmin):
             'admin:%(app_label)s_%(module_label)s_change' % self.app_context,
              args=(obj.pk,)
         )
-        return simple.redirect_to(request,
-            url=redirect_url,
-            permanent=False
-        )
+        return redirect(redirect_url, permanent=False)
 
     def get_changelist_repr(self, node):
         """

--- a/scaffold/admin.py
+++ b/scaffold/admin.py
@@ -362,7 +362,7 @@ class SectionAdmin(admin.ModelAdmin):
             fieldsets = list(inline.get_fieldsets(request))
             readonly = list(inline.get_readonly_fields(request))
             inline_admin_formset = helpers.InlineAdminFormSet(inline, formset,
-                fieldsets, readonly, model_admin=self)
+                fieldsets, readonly_fields=readonly, model_admin=self)
             inline_admin_formsets.append(inline_admin_formset)
             media = media + inline_admin_formset.media
 

--- a/scaffold/admin.py
+++ b/scaffold/admin.py
@@ -48,7 +48,10 @@ class SectionAdmin(admin.ModelAdmin):
 
     def get_urls(self):
 
-        from django.conf.urls.defaults import patterns, url
+        try:
+            from django.conf.urls import patterns, url
+        except ImportError:
+            from django.conf.urls.defaults import patterns, url
 
         def wrap(view):
             def wrapper(*args, **kwargs):

--- a/scaffold/templates/scaffold/admin/add.html
+++ b/scaffold/templates/scaffold/admin/add.html
@@ -1,5 +1,6 @@
 {%extends "admin/change_form.html"%}
 {%load i18n admin_modify static %}
+{% load url from future %}
 {%block extrastyle%}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'scaffold/styles/scaffold-admin.css' %}" type="text/css" media="screen"/>
@@ -7,7 +8,7 @@
 {%endblock%}
 {%block breadcrumbs%}{%if not is_popup%}
 <div class="breadcrumbs">
-    <a href="{%url admin:index%}">{% trans "Home" %}</a> &rsaquo; 
+    <a href="{%url "admin:index"%}">{% trans "Home" %}</a> &rsaquo; 
     <a href="{{app_index_url}}">{{app_label|capfirst|escape}}</a> &rsaquo;      
     <a href="{{changelist_url}}">{{model_label_plural|capfirst}}</a> &rsaquo;
     {%trans "Add"%} {{model_label}}

--- a/scaffold/templates/scaffold/admin/add.html
+++ b/scaffold/templates/scaffold/admin/add.html
@@ -1,5 +1,5 @@
 {%extends "admin/change_form.html"%}
-{%load i18n admin_modify adminmedia static %}
+{%load i18n admin_modify static %}
 {%block extrastyle%}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'scaffold/styles/scaffold-admin.css' %}" type="text/css" media="screen"/>

--- a/scaffold/templates/scaffold/admin/change_form.html
+++ b/scaffold/templates/scaffold/admin/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_modify adminmedia sections %}
+{% load i18n admin_modify sections %}
 {% block breadcrumbs %}{% if not is_popup %}
 <div class="breadcrumbs">
     <a href="{%url admin:index%}">{% trans "Home" %}</a> &rsaquo; 

--- a/scaffold/templates/scaffold/admin/change_form.html
+++ b/scaffold/templates/scaffold/admin/change_form.html
@@ -1,8 +1,9 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_modify sections %}
+{% load url from future %}
 {% block breadcrumbs %}{% if not is_popup %}
 <div class="breadcrumbs">
-    <a href="{%url admin:index%}">{% trans "Home" %}</a> &rsaquo; 
+    <a href="{%url "admin:index"%}">{% trans "Home" %}</a> &rsaquo; 
     <a href="{{app_index_url}}">{{app_label|capfirst|escape}}</a> &rsaquo;      
     {% if has_change_permission %}<a href="{{changelist_url}}">{{ model_label_plural|capfirst }}</a>{% else %}{{ model_label_plural|capfirst }}{% endif %} &rsaquo; 
     {{ original|truncatewords:"18" }}

--- a/scaffold/templates/scaffold/admin/delete.html
+++ b/scaffold/templates/scaffold/admin/delete.html
@@ -1,5 +1,6 @@
 {% extends "admin/delete_confirmation.html" %}
 {% load i18n static %}
+{% load url from future %}
 {% block extrastyle %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'scaffold/styles/scaffold-admin.css' %}" type="text/css" media="screen"/>
@@ -12,7 +13,7 @@
 {%endblock%}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
-    <a href="{%url admin:index%}">{% trans "Home" %}</a> &rsaquo; 
+    <a href="{%url "admin:index"%}">{% trans "Home" %}</a> &rsaquo; 
     <a href="{{app_index_url}}">{{app_label|capfirst}}</a> &rsaquo;      
     <a href="{{changelist_url}}">{{model_label_plural|capfirst}}</a> &rsaquo;
     <a href="{{changelist_url}}{{obj.pk}}/">{{obj.title}}</a> &rsaquo;

--- a/scaffold/templates/scaffold/admin/index.html
+++ b/scaffold/templates/scaffold/admin/index.html
@@ -1,5 +1,6 @@
 {% extends "admin/change_list.html" %}
 {% load i18n static %}
+{% load url from future %}
 
 {% block extrastyle %}
     {{ block.super }}
@@ -13,7 +14,7 @@
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">
-    <a href="{%url admin:index%}">{% trans "Home" %}</a> &rsaquo; 
+    <a href="{%url "admin:index"%}">{% trans "Home" %}</a> &rsaquo; 
     <a href="{{app_index_url}}">{{app_label|capfirst}}</a> &rsaquo;      
     {{model_label_plural|capfirst}}
 </div>

--- a/scaffold/templates/scaffold/admin/move.html
+++ b/scaffold/templates/scaffold/admin/move.html
@@ -1,5 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n static %}
+{% load url from future %}
 {% block extrastyle %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'scaffold/styles/scaffold-admin.css' %}" type="text/css" media="screen"/>
@@ -10,7 +11,7 @@
 {%endblock%}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
-    <a href="{%url admin:index%}">{% trans "Home" %}</a> &rsaquo; 
+    <a href="{%url "admin:index"%}">{% trans "Home" %}</a> &rsaquo; 
     <a href="{{app_index_url}}">{{app_label|capfirst}}</a> &rsaquo;      
     <a href="{{changelist_url}}">{{model_label_plural|capfirst}}</a> &rsaquo;
     <a href="{{changelist_url}}{{obj.pk}}/">{{obj.title}}</a> &rsaquo;

--- a/scaffold/templates/scaffold/admin/order_all_content.html
+++ b/scaffold/templates/scaffold/admin/order_all_content.html
@@ -1,8 +1,8 @@
 {% extends "admin/change_list.html" %}
-{% load i18n adminmedia static %}
+{% load i18n static %}
 {% block extrastyle %}
     {{ block.super }}
-    <link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/forms.css" />
+    <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}" />
     <link rel="stylesheet" href="{% static 'scaffold/styles/scaffold-admin.css' %}" type="text/css" media="screen"/>
     <link rel="stylesheet" href="{% static 'scaffold/styles/jquery.ui.start/jquery.ui.css' %}" type="text/css">   
     <script src="{% static 'scaffold/scripts/jquery.js' %}" type="text/javascript"></script>

--- a/scaffold/templates/scaffold/admin/order_all_content.html
+++ b/scaffold/templates/scaffold/admin/order_all_content.html
@@ -1,5 +1,6 @@
 {% extends "admin/change_list.html" %}
 {% load i18n static %}
+{% load url from future %}
 {% block extrastyle %}
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}" />
@@ -10,7 +11,7 @@
 {%endblock%}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
-    <a href="{%url admin:index%}">{% trans "Home" %}</a> &rsaquo; 
+    <a href="{%url "admin:index"%}">{% trans "Home" %}</a> &rsaquo; 
     <a href="{{app_index_url}}">{{app_label|capfirst}}</a> &rsaquo;      
     <a href="{{changelist_url}}">{{model_label_plural|capfirst}}</a> &rsaquo;
     <a href="{{changelist_url}}{{obj.pk}}/">{{obj.title}}</a> &rsaquo;

--- a/scaffold/templates/scaffold/admin/related_content.html
+++ b/scaffold/templates/scaffold/admin/related_content.html
@@ -1,5 +1,6 @@
 {% extends "admin/change_list.html" %}
 {% load i18n static %}
+{% load url from future %}
 {% block extrastyle %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'scaffold/styles/scaffold-admin.css' %}" type="text/css" media="screen"/>
@@ -10,7 +11,7 @@
 {%endblock%}
 {% block breadcrumbs %}
 <div class="breadcrumbs">
-    <a href="{%url admin:index%}">{% trans "Home" %}</a> &rsaquo; 
+    <a href="{%url "admin:index"%}">{% trans "Home" %}</a> &rsaquo; 
     <a href="{{app_index_url}}">{{app_label|capfirst}}</a> &rsaquo;      
     <a href="{{changelist_url}}">{{model_label_plural|capfirst}}</a> &rsaquo;
     <a href="{{changelist_url}}{{obj.pk}}/">{{obj.title}}</a> &rsaquo;

--- a/scaffold/tests.py
+++ b/scaffold/tests.py
@@ -1,5 +1,8 @@
 from django.conf import settings
-from django.conf.urls.defaults import include, patterns
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 from django.contrib import admin
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured

--- a/scaffold/urls.py
+++ b/scaffold/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 
 urlpatterns = patterns('scaffold.views', 
     url(r'^(?P<section_path>.+)$', 'section', name="section"),

--- a/scaffold/views.py
+++ b/scaffold/views.py
@@ -2,7 +2,8 @@ from django.core.exceptions import MiddlewareNotUsed, ImproperlyConfigured
 from django.contrib.flatpages.views import flatpage
 from django.db.models.loading import AppCache
 from django.http import Http404
-from django.views.generic import simple
+from django.shortcuts import render_to_response
+from django.template import RequestContext
 
 from middleware import get_current_section, lookup_section
 import app_settings 
@@ -19,10 +20,7 @@ def section(request, section_path=None, id_override=None):
         lookup_from = id_override or request
         section = lookup_section(lookup_from)
     if section:
-        return simple.direct_to_template(request, 
-            template = "scaffold/section.html",
-            extra_context = {'section': section}
-        )        
+        return render_to_response("scaffold/section.html", {'section': section}, context_instance=RequestContext(request))
     else:
         app_cache = AppCache()
         try:

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,9 @@ setup(
     ]},
     description=(
         'Reusable application for a generic section/subsection hierarchy'
-        ' in Django 1.3.x'
+        ' in Django 1.4.x'
     ),
     classifiers=classifiers,
     long_description=long_desc,
-    install_requires=['django>=1.3.3','django-treebeard>=1.61']
+    install_requires=['django>=1.4','django-treebeard>=1.61']
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from distutils.core import setup
 
-version = '1.1.2'
+version = '1.1.3'
 
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Use django.shortcuts `render_to_response` and `redirect` instead of deprecated function-based views.

Bumps version to 1.1.3, this should be tagged after PR.

NOTE: setup.py, requirements.txt, and dos say Django 1.3.x is supported, but it is does not function in Django 1.3 given the use of `static` template tag.

changes to resolve issue #27 

This PR also addressed issue #32 
